### PR TITLE
Make multithreading work for speedup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "pybind11"]
+	path = pybind11
+	url = https://github.com/pybind/pybind11.git

--- a/astar_cpp/CMakeLists.txt
+++ b/astar_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.1)
 project(astar_cpp)
 
 IF(NOT CMAKE_BUILD_TYPE)
@@ -13,11 +13,15 @@ FIND_PACKAGE(Eigen3 REQUIRED)
 INCLUDE_DIRECTORIES(${EIGEN3_INCLUDE_DIR})
 
 FIND_PACKAGE(PythonLibs 3 REQUIRED)
+FIND_PACKAGE(Threads)
+FIND_PACKAGE(OpenMP)
 
 add_subdirectory(../pybind11 "${CMAKE_CURRENT_BINARY_DIR}/pybind11_build")
 
 pybind11_add_module(astar_pybind src/astar_pybind.cpp)
 set_target_properties(astar_pybind PROPERTIES PREFIX "" SUFFIX ".so")
 target_include_directories(astar_pybind PRIVATE ${PYTHON_INCLUDE_DIRS}) # ${EIGEN3_INCLUDE_DIRS} 
-target_link_libraries(astar_pybind PRIVATE ${PYTHON_LIBRARIES})
+target_link_libraries(astar_pybind PRIVATE ${PYTHON_LIBRARIES}
+    Threads::Threads
+    OpenMP::OpenMP_CXX)
 

--- a/astar_cpp/tests/test_astar.py
+++ b/astar_cpp/tests/test_astar.py
@@ -1,0 +1,32 @@
+
+import numpy as np
+
+import astar_pybind as pyAstar
+
+
+def test_astar():
+
+    batch_size = 2
+    num_controls = 4        # 0: +x , 1: +y, 2: -x, 3: -y
+    grid_size = 8
+
+    # constant cost of 1 for moving in any direction    
+    cost = np.ones((batch_size, num_controls, grid_size, grid_size), dtype=np.float32)
+    start = np.array([[i, 1] for i in range(batch_size)], dtype=np.int32)
+    goal = np.array([[7, 7] for _ in range(batch_size)], dtype=np.int32)
+
+    # Q(i, u) is the Q value from start[i] to goal[i] if first action is u
+    Q = np.zeros((batch_size, num_controls), dtype=np.float32)
+
+    # gradient of Q wrt cost
+    dQdc = np.zeros((batch_size, num_controls, num_controls, 
+                           grid_size, grid_size), dtype=np.float32)
+
+    # g value for each state to goal 
+    g = np.ones((batch_size, grid_size, grid_size), dtype=np.float32) * 1e6
+
+    pyAstar.planBatch2DGrid(cost, start, goal, Q, dQdc, g)
+
+
+if __name__ == '__main__':
+    test_astar()

--- a/astar_cpp/tests/test_astar.py
+++ b/astar_cpp/tests/test_astar.py
@@ -2,7 +2,8 @@
 import numpy as np
 
 import astar_pybind as pyAstar
-
+import timeit
+import os
 
 def test_astar():
 
@@ -24,8 +25,19 @@ def test_astar():
 
     # g value for each state to goal 
     g = np.ones((batch_size, grid_size, grid_size), dtype=np.float32) * 1e6
+    try:
+        _ = os.environ["OMP_NUM_THREADS"]
+    except KeyError:
+        print("Please set OMP_NUM_THREADS before calling");
+        raise
 
-    pyAstar.planBatch2DGrid(cost, start, goal, Q, dQdc, g)
+    print("Threads : %s; Time: " % os.environ["OMP_NUM_THREADS"],
+        timeit.timeit(
+            lambda: pyAstar.planBatch2DGrid(cost, start, goal, Q, dQdc, g),
+            number=1000,
+            globals=locals())
+         )
+
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The only thing, I needed to change was make sure that no python call was being made even by pybind11. The code to run in each thread needs to be pure cpp, no python.

```
$ OMP_NUM_THREADS=1 PYTHONPATH=lib python3.8 tests/test_astar.py 
Threads : 1; Time:  0.12287582800036034
$ OMP_NUM_THREADS=2 PYTHONPATH=lib python3.8 tests/test_astar.py 
Threads : 2; Time:  0.06965051999941352
```